### PR TITLE
Show percent value in semicircle when props.showPercentValue is true

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ class Example extends Component {
 * `props.diameter` - number, optional, diameter of the semicricle (default `200`)
 * `props.orientation` - string, optional, specifies the orientation of the semicircle. Currently supports `'up'` and `'down'` (default `'up'`)
 * `props.percentage` - number, _required_, percentage to be drawn on the bar
+* `props.showPercentValue` - boolean, optional, show percentage value as a number in the middle of semicircle (default `false`)
 
 ## [Demo](https://thomasbem.github.io/react-progressbar-semicircle/)
 

--- a/example/src/App.js
+++ b/example/src/App.js
@@ -7,6 +7,7 @@ export default class App extends Component {
     return (
       <div>
         <SemiCircleProgressBar percentage={33} />
+        <SemiCircleProgressBar percentage={33} showPercentValue />
       </div>
     );
   }

--- a/src/index.js
+++ b/src/index.js
@@ -1,8 +1,6 @@
 import React, { Component } from "react";
 import PropTypes from "prop-types";
 
-import styles from "./styles.css";
-
 const SemiCircleProgress = ({
   stroke = "#02B732",
   strokeWidth = 10,
@@ -20,7 +18,7 @@ const SemiCircleProgress = ({
   const semiCirclePercentage = percentage * (circumference / 100);
 
   return (
-    <div className={styles.root} style={{ position: "relative" }}>
+    <div className="semicircle-container" style={{ position: "relative" }}>
       <svg width={diameter} height={diameter / 2}>
         <circle
           cx={coordinateForCircle}
@@ -53,7 +51,7 @@ const SemiCircleProgress = ({
       </svg>
       {showPercentValue && (
         <span
-          className="percent-value"
+          className="semicircle-percent-value"
           style={{
             left: `calc((${diameter / 2}px - ${
               percentage < 100 ? (percentage > 10 ? "16px" : "11.5px") : "20px"

--- a/src/index.js
+++ b/src/index.js
@@ -9,6 +9,7 @@ const SemiCircleProgress = ({
   background = "#D0D0CE",
   diameter = 200,
   orientation = "up",
+  showPercentValue = false,
   percentage
 }) => {
   const coordinateForCircle = diameter / 2;
@@ -19,7 +20,7 @@ const SemiCircleProgress = ({
   const semiCirclePercentage = percentage * (circumference / 100);
 
   return (
-    <div className={styles.root}>
+    <div className={styles.root} style={{ position: "relative" }}>
       <svg width={diameter} height={diameter / 2}>
         <circle
           cx={coordinateForCircle}
@@ -50,6 +51,20 @@ const SemiCircleProgress = ({
           }}
         />
       </svg>
+      {showPercentValue && (
+        <span
+          className="percent-value"
+          style={{
+            left: `calc((${diameter / 2}px - ${
+              percentage < 100 ? (percentage > 10 ? "16px" : "11.5px") : "20px"
+            } ))`,
+            bottom: "0",
+            position: "absolute"
+          }}
+        >
+          {percentage}%
+        </span>
+      )}
     </div>
   );
 };
@@ -60,6 +75,7 @@ SemiCircleProgress.propTypes = {
   background: PropTypes.string,
   diameter: PropTypes.number,
   orientation: PropTypes.string,
+  showPercentValue: PropTypes.bool,
   percentage: PropTypes.number
 };
 

--- a/src/styles.css
+++ b/src/styles.css
@@ -1,0 +1,6 @@
+:local(.root) {
+  position: relative;
+}
+:local(.root) :local(.percentValue) {
+  position: absolute;
+}

--- a/src/styles.css
+++ b/src/styles.css
@@ -1,6 +1,0 @@
-:local(.root) {
-  position: relative;
-}
-:local(.root) :local(.percentValue) {
-  position: absolute;
-}


### PR DESCRIPTION
#2 This PR makes it possible to show the percent value inside the semicircle progress bar when props.showPercentValue is set to true.

An example is also added into the examples app. So that this will show up in Github pages when you deploy a new version there.