### PR TITLE
Improve prop definitions

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -81,6 +81,30 @@ const SemiCircleProgress = ({
   );
 };
 
+function percentageValidation(isRequired) {
+  return function(props, propName, componentName) {
+    const prop = props[propName];
+    if (prop == null) {
+      if (isRequired) {
+        throw new Error("Percentage is a required prop.");
+      }
+    } else {
+      if (typeof prop !== "number") {
+        return new Error(
+          "Invalid percentage. Must be a number between 0 and 100."
+        );
+      }
+      if (props[propName] < 0 || props[propName] > 100) {
+        return new Error(
+          "Invalid percentage. Must be a number between 0 and 100."
+        );
+      }
+    }
+  };
+}
+
+const percentageisRequired = percentageValidation(true);
+
 SemiCircleProgress.propTypes = {
   stroke: PropTypes.string,
   strokeWidth: PropTypes.number,
@@ -89,7 +113,7 @@ SemiCircleProgress.propTypes = {
   orientation: PropTypes.oneOf(["up", "down"]),
   direction: PropTypes.oneOf(["left", "right"]),
   showPercentValue: PropTypes.bool,
-  percentage: PropTypes.number.isRequired
+  percentage: percentageisRequired
 };
 
 export default SemiCircleProgress;

--- a/src/index.js
+++ b/src/index.js
@@ -86,10 +86,10 @@ SemiCircleProgress.propTypes = {
   strokeWidth: PropTypes.number,
   background: PropTypes.string,
   diameter: PropTypes.number,
-  orientation: PropTypes.string,
-  direction: PropTypes.string,
+  orientation: PropTypes.oneOf(["up", "down"]),
+  direction: PropTypes.oneOf(["left", "right"]),
   showPercentValue: PropTypes.bool,
-  percentage: PropTypes.number
+  percentage: PropTypes.number.isRequired
 };
 
 export default SemiCircleProgress;


### PR DESCRIPTION
Orientation now only supports 'up' and 'down', any other input will trigger an error in console and alert user of what the supported values are. Same goes for direction.

Adds a custom prop validation to 'percentage', which validate the type and checks if it is between 0 and 100 and makes it required.

This PR should close #11 