### PR TITLE
fix: correct the radius calculation

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -12,7 +12,7 @@ const SemiCircleProgress = ({
   percentage
 }) => {
   const coordinateForCircle = diameter / 2;
-  const radius = (diameter - 2 * strokeWidth) / 2;
+  const radius = (diameter - strokeWidth) / 2;
   const circumference = Math.PI * radius;
 
   let percentageValue;


### PR DESCRIPTION
According to [this](https://developer.mozilla.org/en-US/docs/Web/SVG/Tutorial/Fills_and_Strokes), strokes are drawn centered around the path, so radius should be *diameter/2 - strokeWidth/2*